### PR TITLE
This plug-in sometimes causes E31

### DIFF
--- a/after/ftplugin/vim/backslash.vim
+++ b/after/ftplugin/vim/backslash.vim
@@ -51,6 +51,6 @@ imap <buffer> <CR> <Plug>(backslash-CR-i)
 
 let b:undo_ftplugin =
       \ get(b:, 'undo_ftplugin', '')
-      \ . '| nunmap <buffer> o'
-      \ . '| iunmap <buffer> <CR>'
+      \ . '| silent! nunmap <buffer> o'
+      \ . '| silent! iunmap <buffer> <CR>'
 let b:undo_ftplugin = substitute(b:undo_ftplugin, '^| ', '', '')


### PR DESCRIPTION
In an interaction with two plug-ins that set `b:undo_ftplugin` (the other is
caw.vim) for the vim filetype, I was seeing an `E31: No such mapping` error. I
traced it to this plug-in.

What's weird is that the error happens on startup (that is, I was *just*
editing a vim configuration file in a fresh instance of vim). However, adding
`silent!` to the unmaps in this plug-in's `b:undo_ftplugin` setting silences
the error.