### PR TITLE
Add mapping for O and add backslash when opening dict or list.

### DIFF
--- a/after/ftplugin/vim/backslash.vim
+++ b/after/ftplugin/vim/backslash.vim
@@ -3,16 +3,36 @@ if exists('b:backslash_loaded')
 endif
 let b:backslash_loaded = 1
 
+let s:leading_dict_list_open_rgx = '^.*\(\[\|{\)$'
+let s:leading_dict_list_rgx = '^.*\(\[\(.*\]\)\?\|{\(.*}\)\?\)$'
+
 function! s:is_continuous() abort
-  return getline('.') =~# '^\s*\\\s*'
+  return getline('.') =~# '^\s*\\\s*' || getline('.') =~# s:leading_dict_list_open_rgx
+endfunction
+
+function! s:is_continuous_cr() abort
+  return getline('.') =~# '^\s*\\\s*' || getline('.') =~# s:leading_dict_list_rgx
 endfunction
 
 function! s:smart_o() abort
   let lnum = line('.')
   let line = getline(lnum)
   let leading = matchstr(line, '^\s*\\\s*')
+  if empty(leading) && line =~# s:leading_dict_list_open_rgx
+    let indent = get(g:, 'vim_indent_cont', shiftwidth() * 3)
+    let leading = repeat(' ', indent) . '\ '
+  endif
   call append(lnum, leading)
   call setpos('.', [0, lnum+1, 0, 0])
+  startinsert!
+endfunction
+
+function! s:smart_O() abort
+  let lnum = line('.')
+  let line = getline(lnum)
+  let leading = matchstr(line, '^\s*\\\s*')
+  call append(lnum-1, leading)
+  call setpos('.', [0, lnum, 0, 0])
   startinsert!
 endfunction
 
@@ -26,31 +46,41 @@ function! s:smart_CR_i() abort
     call setpos('.', [0, lnum, 0, 0])
     startinsert!
     return
-  else
-    let leading = matchstr(line, '^\s*\\\s*')
-    let prefix = line[:col('.')-1]
-    let suffix = line[col('.'):]
-    call setline('.', prefix)
-    call append(lnum, leading . suffix)
-    call setpos('.', [0, lnum+1, len(leading)+1, 0])
-    execute len(suffix) ? 'startinsert' : 'startinsert!'
-    return
   endif
+
+  let leading = matchstr(line, '^\s*\\\s*')
+  if empty(leading) && line =~# s:leading_dict_list_rgx
+    let indent = get(g:, 'vim_indent_cont', shiftwidth() * 3)
+    let leading = repeat(' ', indent) . '\ '
+  endif
+  let prefix = line[:col('.')-1]
+  let suffix = line[col('.'):]
+  call setline('.', prefix)
+  call append(lnum, leading . suffix)
+  call setpos('.', [0, lnum+1, len(leading)+1, 0])
+  execute len(suffix) ? 'startinsert' : 'startinsert!'
+  return
 endfunction
 
 nnoremap <silent><buffer><expr> <Plug>(backslash-o) <SID>is_continuous()
       \ ? ":\<C-u>call \<SID>smart_o()\<CR>"
       \ : 'o'
 
-inoremap <silent><buffer><expr> <Plug>(backslash-CR-i) <SID>is_continuous()
+nnoremap <silent><buffer><expr> <Plug>(backslash-O) <SID>is_continuous()
+      \ ? ":\<C-u>call \<SID>smart_O()\<CR>"
+      \ : 'O'
+
+inoremap <silent><buffer><expr> <Plug>(backslash-CR-i) <SID>is_continuous_cr()
       \ ? "\<Esc>:\<C-u>call \<SID>smart_CR_i()\<CR>"
       \ : "\<CR>"
 
 nmap <buffer> o    <Plug>(backslash-o)
+nmap <buffer> O    <Plug>(backslash-O)
 imap <buffer> <CR> <Plug>(backslash-CR-i)
 
 let b:undo_ftplugin =
       \ get(b:, 'undo_ftplugin', '')
       \ . '| silent! nunmap <buffer> o'
+      \ . '| silent! nunmap <buffer> O'
       \ . '| silent! iunmap <buffer> <CR>'
 let b:undo_ftplugin = substitute(b:undo_ftplugin, '^| ', '', '')


### PR DESCRIPTION
This pr adds:

* Adding backslash on O (line above)
* Improve o to add backslash for opened dictionary or list
```vimL
let s:my_dict = {<CR>
```
generates:
```vimL
let s:my_dict = {
      \ 
```
* Improve <CR> to add backslash for opened dictiionary or list (as o above), and also for closed ones. Example:

```vimL
let s:my_dict = [<CR>]
```
generates:
```vimL
let s:my_dict = [
      \ |]
```

And:
```vimL
let s:my_dict =[{<CR>}]
```
generates:
```vimL
let s:my_dict = [{
      \ }]
```