### PR TITLE
Add backslash for brackets and fix CR bug where backslash was added incorrectly.

### DIFF
--- a/after/ftplugin/vim/backslash.vim
+++ b/after/ftplugin/vim/backslash.vim
@@ -13,7 +13,7 @@ function! s:is_continuous_cr() abort
   let line = getline('.')
   let prefix = line[:col('.')-2]
   let suffix = line[col('.')-1:]
-  let should_add_backslash = suffix =~# '^.*\(\]\|}\|)\)$'
+  let should_add_backslash = suffix =~# '^.*\(\]\|}\|)\).*$'
         \ || (prefix =~# '^.*\(\[\|{\|(\)$' && suffix =~# '^\s*$')
 
   return line =~# '^\s*\\\s*' || should_add_backslash
@@ -75,9 +75,20 @@ nnoremap <silent><buffer><expr> <Plug>(backslash-O) <SID>is_continuous()
       \ ? ":\<C-u>call \<SID>smart_O()\<CR>"
       \ : 'O'
 
-inoremap <silent><buffer><expr> <Plug>(backslash-CR-i) <SID>is_continuous_cr()
-      \ ? "\<Esc>:\<C-u>call \<SID>smart_CR_i()\<CR>"
-      \ : "\<CR>"
+let s:cr_mappings = maparg('<CR>', 'i')
+if empty(s:cr_mappings)
+  inoremap <silent><buffer><expr> <Plug>(backslash-CR-i) <SID>is_continuous_cr()
+        \ ? "\<Esc>:\<C-u>call \<SID>smart_CR_i()\<CR>"
+        \ : "\<CR>"
+else
+  function! s:fallback_cr() abort
+    return eval('"'.escape(s:cr_mappings, '<').'"')
+  endfunction
+
+  imap <silent><buffer><expr> <Plug>(backslash-CR-i) <SID>is_continuous_cr()
+        \ ? "\<Esc>:\<C-u>call \<SID>smart_CR_i()\<CR>"
+        \ : <SID>fallback_cr()
+endif
 
 nmap <buffer> o    <Plug>(backslash-o)
 nmap <buffer> O    <Plug>(backslash-O)

--- a/after/ftplugin/vim/backslash.vim
+++ b/after/ftplugin/vim/backslash.vim
@@ -3,15 +3,20 @@ if exists('b:backslash_loaded')
 endif
 let b:backslash_loaded = 1
 
-let s:leading_dict_list_open_rgx = '^.*\(\[\|{\)$'
-let s:leading_dict_list_rgx = '^.*\(\[\(.*\]\)\?\|{\(.*}\)\?\)$'
+let s:leading_dict_list_open_rgx = '^.*\(\[\|{\|(\)$'
 
 function! s:is_continuous() abort
   return getline('.') =~# '^\s*\\\s*' || getline('.') =~# s:leading_dict_list_open_rgx
 endfunction
 
 function! s:is_continuous_cr() abort
-  return getline('.') =~# '^\s*\\\s*' || getline('.') =~# s:leading_dict_list_rgx
+  let line = getline('.')
+  let prefix = line[:col('.')-2]
+  let suffix = line[col('.')-1:]
+  let should_add_backslash = suffix =~# '^.*\(\]\|}\|)\)$'
+        \ || (prefix =~# '^.*\(\[\|{\|(\)$' && suffix =~# '^\s*$')
+
+  return line =~# '^\s*\\\s*' || should_add_backslash
 endfunction
 
 function! s:smart_o() abort
@@ -49,7 +54,7 @@ function! s:smart_CR_i() abort
   endif
 
   let leading = matchstr(line, '^\s*\\\s*')
-  if empty(leading) && line =~# s:leading_dict_list_rgx
+  if empty(leading)
     let indent = get(g:, 'vim_indent_cont', shiftwidth() * 3)
     let leading = repeat(' ', indent) . '\ '
   endif


### PR DESCRIPTION
I forgot to add regular brackets to my previous PR, so i'm adding it now.
Also, during the testing of the brackets, i found a bug in my previous PR where doing this:

```
let g:test_dict = []<CR>
```

Would add backslash, but it shouldn't. Now it's fixed.